### PR TITLE
show pure text in code example of preview

### DIFF
--- a/packages/styleguide/src/components/Preview/CodeExample.js
+++ b/packages/styleguide/src/components/Preview/CodeExample.js
@@ -33,6 +33,11 @@ const getJSXAsStringFromMarkup = (markup, options) => {
       .join('\n');
   }
 
+  // if it's pure text, return it
+  if (typeof markup === 'string') {
+    return markup;
+  }
+
   return '';
 };
 


### PR DESCRIPTION
pure text was not shown in code example if passed to preview