### PR TITLE
add prism support for scss/sass

### DIFF
--- a/packages/styleguide/src/components/Code/Code.js
+++ b/packages/styleguide/src/components/Code/Code.js
@@ -8,6 +8,7 @@ import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-json';
 import 'prismjs/components/prism-diff';
+import 'prismjs/components/prism-sass';
 import 'prism-theme-one-dark/prism-onedark.css';
 import 'firacode/distr/fira_code.css';
 


### PR DESCRIPTION
- add support for sass/scss prism
- both syntaxes working only with language="sass" ( value scss doesn' have support )
