### PR TITLE
fix ComponentsDocs `path` not displaing props table

### DIFF
--- a/packages/styleguide/src/components/ComponentDocs/ComponentDocs.js
+++ b/packages/styleguide/src/components/ComponentDocs/ComponentDocs.js
@@ -73,7 +73,8 @@ class ComponentDocs extends Component {
       excludeProps(
         this.props.excludes,
         getTableData(
-          getComponentInfoFromComponent(this.props.component) || this.state.info
+          getComponentInfoFromComponent(this.props.component).length ||
+            this.state.info
         )
       )
     );


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
