### PR TITLE
update react-router-dom deprecated imports in lighter-app

### DIFF
--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -35,7 +35,7 @@
     "react-frame-component": "~4.0.0",
     "react-markings": "~1.3.0",
     "react-responsive": "~6.0.1",
-    "react-router-dom": "~4.3.1",
+    "react-router-dom": "~4.4.0",
     "react-select": "~2.2.0",
     "styled-components": "~4.1.2",
     "svg4everybody": "~2.1.9",


### PR DESCRIPTION
hádzalo mi chybu v lighter-app a padalo to na react-router importoch v react-router-dom balíku