### PR TITLE
rename built component stylesheets to style.css

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -734,7 +734,11 @@ module.exports = function(webpackEnv, options = {}) {
         new MiniCssExtractPlugin({
           // Options similar to the same options in webpackOptions.output
           // both options are optional
-          filename: '[name].css',
+          // component stylesheets are renamed to style.css
+          filename: chunkData =>
+            chunkData.chunk.name.startsWith('components/')
+              ? `${chunkData.chunk.name.replace('index', 'style')}.css`
+              : '[name].css',
           chunkFilename: '[name].css',
         }),
       // Generate an asset manifest file with the following content:

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -733,9 +733,9 @@ module.exports = function(webpackEnv, options = {}) {
         // Options similar to the same options in webpackOptions.output
         // both options are optional
         // component stylesheets are renamed to style.css
-        filename: chunkData =>
-          chunkData.chunk.name.startsWith('components/')
-            ? `${chunkData.chunk.name.replace('index', 'style')}.css`
+        moduleFilename: ({ name }) =>
+          name.startsWith('components/')
+            ? `${name.replace('index', 'style')}.css`
             : '[name].css',
         chunkFilename: '[name].css',
       }),


### PR DESCRIPTION
po zmenach sa zacali komponentie stylesheety buildit do filu s nazvom index.css
nakolko sa v oranzi pouzivaju importy takto vybuildenych assetov, pomoze nam ked to bude po starom.

hocico v src/components/**/index.css bude premenovane na style.css.

viem, dalo by sa to spravit regexami krajsie, ale tie sa naprd citaju. a naprd pisu :) https://overreacted.io/goodbye-clean-code/