### PR TITLE
add new entries from lib to development

### DIFF
--- a/packages/react-scripts/scripts/start.js
+++ b/packages/react-scripts/scripts/start.js
@@ -106,6 +106,7 @@ choosePort(HOST, DEFAULT_PORT)
       configFactory('development', {
         entries: {
           ...getEntries('', paths.appSrc, '/index.js'),
+          ...getEntries('lib', paths.libDir, '/*.js'),
           ...spaEntries,
         },
         spaHtmlPaths,

--- a/packages/react-scripts/scripts/utils/getEntries.js
+++ b/packages/react-scripts/scripts/utils/getEntries.js
@@ -6,25 +6,28 @@ const path = require('path');
 function getEntries(type, dirPath, globRegex) {
   const entryFiles = glob.sync(path.join(dirPath, globRegex));
 
-  return entryFiles
-    .reduce((entries, entryFile) => {
-      // converts entryFile path to platform specific style
-      // this fixes windows/unix path inconsitence
-      // because node-glob always returns path with unix style path separators
-      entryFile = path.join(entryFile);
+  return entryFiles.reduce((entries, entryFile) => {
+    // converts entryFile path to platform specific style
+    // this fixes windows/unix path inconsitence
+    // because node-glob always returns path with unix style path separators
+    entryFile = path.join(entryFile);
 
-      const localPath = entryFile.split(dirPath)[1];
+    const localPath = entryFile.split(dirPath)[1];
 
-      let entryName = path
-        // create entry name
-        .join(type, localPath.split('.js')[0])
-        // remove leading slash
-        .replace(/^\/|\/$/g, '');
+    let entryName = path
+      // create entry name
+      .join(type, localPath.split('.js')[0])
+      // remove leading slash
+      .replace(/^\/|\/$/g, '')
+      // replace slash for dash
+      // (slash is not allowed as a filename character)
+      // entryName is used for creating filename in webpack
+      .replace('/', '-');
 
-      entries[entryName] = path.join(dirPath, localPath);
+    entries[entryName] = path.join(dirPath, localPath);
 
-      return entries;
-    }, {});
+    return entries;
+  }, {});
 }
 
 module.exports = getEntries;


### PR DESCRIPTION
there was this problem with static js files not really showing up in a project anywhere else than in a build folder, so we need to make these files visible for development use

- get all js files from lib folder and make it usable in dev mode
- remove slash from entryName because its not allowed to have slash in filename