### PR TITLE
Fix/ul default styles

### DIFF
--- a/packages/styleguide/src/components/Navigation/index.js
+++ b/packages/styleguide/src/components/Navigation/index.js
@@ -121,7 +121,7 @@ const StyledNav = styled.nav`
   font-family: ${props => props.theme.fontFamily};
   font-size: ${props => rem(props.theme.fontSizes.base)};
   line-height: ${props => props.theme.lineHeights.base};
-  margin: ${props => rem(props.theme.spaces.default)} 0;
+  margin-top: ${props => rem(props.theme.spaces.default)};
 `;
 
 const StyledNavList = styled.ul`

--- a/packages/styleguide/src/components/Navigation/index.js
+++ b/packages/styleguide/src/components/Navigation/index.js
@@ -121,6 +121,7 @@ const StyledNav = styled.nav`
   font-family: ${props => props.theme.fontFamily};
   font-size: ${props => rem(props.theme.fontSizes.base)};
   line-height: ${props => props.theme.lineHeights.base};
+  margin: ${props => rem(props.theme.spaces.default)} 0;
 `;
 
 const StyledNavList = styled.ul`
@@ -133,6 +134,7 @@ const StyledNavList = styled.ul`
   font-weight: 700;
   transition: max-height 0.1s cubic-bezier(0, 1, 0.01, 0.98) 0s,
     padding 0.25s cubic-bezier(0, 1, 0.01, 0.98) 0s;
+  margin: 0;
 `;
 
 const ListItem = styled.li`

--- a/packages/styleguide/src/components/Search/Search.js
+++ b/packages/styleguide/src/components/Search/Search.js
@@ -168,7 +168,8 @@ const StyledAutocompleteWrapper = styled.div`
       max-height: calc(8.25 * 52px);
       overflow: auto;
       left: 50%;
-      transform: translate(-50%, -17px);
+      transform: translate(-50%, 0);
+      margin: 0;
     }
   }
 

--- a/packages/styleguide/src/components/Search/Search.js
+++ b/packages/styleguide/src/components/Search/Search.js
@@ -150,7 +150,8 @@ const StyledAutocompleteWrapper = styled.div`
   }
 
   .autocomplete__option--focused {
-    background: #eee;
+    color: ${props => props.theme.colors.black};
+    background: ${props => props.theme.colors.grey};
   }
 
   .autocomplete__menu {


### PR DESCRIPTION
`ul` had a default style and using reset or normalize in project removed default margins
- margins are now set in navigation and autocomplete menu components