### PR TITLE
Allow support for glob syntax in scss imports

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -45,6 +45,7 @@ const { JSDOM } = require('jsdom');
 const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
 
 const remarkEmoji = require('remark-emoji');
+const globImporter = require('node-sass-glob-importer');
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
@@ -213,6 +214,9 @@ module.exports = function(webpackEnv, options = {}) {
           loader: require.resolve(preProcessor),
           options: {
             sourceMap: true,
+            sassOptions: {
+              importer: preProcessor === 'sass-loader' && globImporter(),
+            },
           },
         }
       );
@@ -602,7 +606,7 @@ module.exports = function(webpackEnv, options = {}) {
                 {
                   loader: require.resolve('@mdx-js/loader'),
                   options: {
-                    remarkPlugins: [ remarkEmoji ],
+                    remarkPlugins: [remarkEmoji],
                   },
                 },
               ],

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -214,8 +214,8 @@ module.exports = function(webpackEnv, options = {}) {
           loader: require.resolve(preProcessor),
           options: {
             sourceMap: true,
-            sassOptions: {
-              importer: preProcessor === 'sass-loader' && globImporter(),
+            sassOptions: preProcessor === 'sass-loader' && {
+              importer: globImporter(),
             },
           },
         }

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -61,6 +61,7 @@
     "jsdom": "13.0.0",
     "mini-css-extract-plugin": "0.8.0",
     "node-sass": "^4.12.0",
+    "node-sass-glob-importer": "^5.3.2",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.5.0",
     "postcss-flexbugs-fixes": "4.1.0",
@@ -88,7 +89,6 @@
     "workbox-webpack-plugin": "4.3.1"
   },
   "devDependencies": {
-    "node-sass-glob-importer": "^5.3.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"
   },

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -88,6 +88,7 @@
     "workbox-webpack-plugin": "4.3.1"
   },
   "devDependencies": {
+    "node-sass-glob-importer": "^5.3.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0"
   },


### PR DESCRIPTION
Toto dovoli robit `@import '../components/**/style` a funguje.

Nadabil som na habaduru, kedy sa mi to pobilo s boostedom.

v [config.scss](https://bitbucket.org/lightingbeetle/orange-design-system/src/master/src/components/Shape/styles/config.scss) som mal definovanu premennu `$colors`, ktora prepisala [rovnako pomenovanu !default premennu](https://github.com/Orange-OpenSource/Orange-Boosted-Bootstrap/blob/v4-dev/scss/_variables.scss#L51) 

je zaujimave, ze sa to dojebabralo az teraz, nakolko to malo imho padnut uz skorej 🤷‍♂ 