### PR TITLE
Fix/preview html

### DIFF
--- a/packages/styleguide/src/components/MDX/MDX.js
+++ b/packages/styleguide/src/components/MDX/MDX.js
@@ -36,7 +36,10 @@ export const MDXComponents = {
   a: props => <Link {...props} />,
   inlineCode: props => <Code {...props} />,
   code: props => (
-    <CodeBlock language={props.className.replace(/language-/, '')} {...props} />
+    <CodeBlock
+      language={props.className && props.className.replace(/language-/, '')}
+      {...props}
+    />
   ),
 };
 

--- a/packages/styleguide/src/components/Preview/CodeExample.js
+++ b/packages/styleguide/src/components/Preview/CodeExample.js
@@ -211,6 +211,7 @@ export default class CodeExample extends React.Component {
         <Code
           inline={false}
           ref={this.codeBlockRef}
+          data-testid={this.state.codePreviewType}
           language={
             this.state.codePreviewType === 'html'
               ? 'markup'

--- a/packages/styleguide/src/components/Preview/CodeExample.js
+++ b/packages/styleguide/src/components/Preview/CodeExample.js
@@ -167,7 +167,7 @@ export default class CodeExample extends React.Component {
   }
 
   render() {
-    const { children, codeJSXOptions, codeTypes, theme, ...other } = this.props;
+    const { children, codeJSXOptions, codeTypes, ...other } = this.props;
 
     let codeToShow;
     switch (this.state.codePreviewType) {
@@ -175,10 +175,7 @@ export default class CodeExample extends React.Component {
         codeToShow = pretty(
           typeof children === 'string'
             ? unescape(children)
-            : renderToStaticMarkup({
-                ...children,
-                props: { ...children.props, theme },
-              }),
+            : renderToStaticMarkup(children),
           {
             ocd: true,
           }

--- a/packages/styleguide/src/components/Preview/Preview.test.js
+++ b/packages/styleguide/src/components/Preview/Preview.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import Preview from '.';
 
@@ -7,5 +7,20 @@ describe('rendering', () => {
   it('Preview', () => {
     const { getByText } = render(<Preview>Preview</Preview>);
     expect(getByText('Preview')).toBeInTheDocument();
+  });
+
+  it('HTML preview renders more than 1 child', () => {
+    const { getByText, getByTestId } = render(
+      <Preview>
+        <p>Paragraph 1</p>
+        <p>Paragraph 2</p>
+      </Preview>
+    );
+
+    fireEvent.click(getByText('SHOW CODE'));
+
+    fireEvent.click(getByText('HTML'));
+
+    expect(getByTestId('html')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
taktom. 

povodcom html code example erroru ked ma viac children bol tento fix https://github.com/lightingbeetle/lighter/pull/117 ktory opravoval styled components. po tejto zmene som nezaznamenal ze by nieco prestalo ist.

napisal som test.

rucne som preklikal vsetky previews v lighter-styleguide a lighter-app a pozeral ci funguju. funguju. dokonca aj `code` prop, ktory ideme deprecatnut :)

