### PR TITLE
Release/3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.5.3 (Mar 4, 2020)
+
+- [lighter-styleguide] fix code preview crashing when rendering more than one child ([#209](https://github.com/lightingbeetle/lighter/pull/209))
+- [lighter-styleguide] fix MDX codeblock crashing when no language is specified ([#210](https://github.com/lightingbeetle/lighter/pull/210))
+
+#### :tata: version updates
+
+- `lighter-stylegiude@3.3.3`
+
 ## 3.5.2 (Mar 3, 2020)
 
 This update is necessary due to incorrect publish of `lighter-stylegiude@3.3.1`

--- a/packages/styleguide/package-lock.json
+++ b/packages/styleguide/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@lighting-beetle/lighter-styleguide",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/styleguide/package.json
+++ b/packages/styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lighting-beetle/lighter-styleguide",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Lighter styleguide",
   "main": "build/components/index.js",
   "files": [


### PR DESCRIPTION
## 3.5.3 (Mar 4, 2020)

- [lighter-styleguide] fix code preview crashing when rendering more than one child ([#209](https://github.com/lightingbeetle/lighter/pull/209))
- [lighter-styleguide] fix MDX codeblock crashing when no language is specified ([#210](https://github.com/lightingbeetle/lighter/pull/210))

#### :tata: version updates

- `lighter-stylegiude@3.3.3`
